### PR TITLE
Fix for Node V0.4.0

### DIFF
--- a/bin/jasbin
+++ b/bin/jasbin
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-var jasmine = require('jasbin');
+var jasmine = require('jasmine-node');
 
 // coffeescript support if you have coffee-script installed
 try {


### PR DESCRIPTION
Node changed the require() module, which broke how jasbin worked. The change I did fixes this error:

node.js:116
        throw e; // process.nextTick error, or 'error' event on first tick
        ^
Error: Cannot find module 'jasbin'
    at Function._resolveFilename (module.js:289:11)
    at Function._load (module.js:241:25)
    at require (module.js:317:19)
    at Object.<anonymous> (/usr/local/lib/node/.npm/jasbin/1.0.8/package/bin/jasbin:2:15)
    at Module._compile (module.js:373:26)
    at Object..js (module.js:379:10)
    at Module.load (module.js:305:31)
    at Function._load (module.js:271:10)
    at Array.<anonymous> (module.js:392:10)
    at EventEmitter._tickCallback (node.js:108:26)

I haven't checked the compatibility of this with relation to previous versions of NodeJS, but if I get round to it before someone else does and it works fine, I'll let you know.
