### PR TITLE
Update for node 0.6

### DIFF
--- a/bin/jasbin
+++ b/bin/jasbin
@@ -31,6 +31,5 @@ process.argv.slice(2).forEach(function(arg){
 });
 
 jasmine.executeSpecsInFolder(process.cwd() + '/spec', function(runner, log){
-	process.stdout.flush(); process.stdout.end();
 	process.exit(runner.results().failedCount);
 }, isVerbose, showColors, matcher);


### PR DESCRIPTION
Fixes the following 2 errors:

events.js:48
        throw arguments[1]; // Unhandled 'error' event
                       ^
Error: process.stdout cannot be closed.
    at WriteStream.<anonymous> (node.js:284:20)
    at WriteStream.end (net.js:241:10)
    at /Users/plyons/projects/othenticate.com/node_modules/jasbin/bin/jasbin:34:17

Users/plyons/projects/othenticate.com/node_modules/jasbin/bin/jasbin:34
    process.stdout.flush(); process.stdout.end();
                ^
TypeError: Object #<WriteStream> has no method 'flush'
    at /Users/plyons/projects/othenticate.com/node_modules/jasbin/bin/jasbin:34:17
